### PR TITLE
cleanup feature extraction

### DIFF
--- a/general_autoencoder.py
+++ b/general_autoencoder.py
@@ -21,7 +21,6 @@ class GeneralAutoencoder(DimReducer):
         non_linearity='relu'):
 
         self.need_ages = False
-
         # How many epochs should pass before we evaluate and print out
         # the loss on the training/validation datasets?
         self.num_epochs_before_eval = 1
@@ -146,7 +145,6 @@ class GeneralAutoencoder(DimReducer):
 
             self.X = tf.placeholder("float32", [None, len(self.feature_names)])
             self.ages = tf.placeholder("float32", None)
-
             self.init_network()
             self.Z = self.encode(self.X)
             self.Xr = self.decode(self.Z)
@@ -161,7 +159,6 @@ class GeneralAutoencoder(DimReducer):
             
             # create a saver object so we can save the model if we want. 
             self.saver = tf.train.Saver()
-                
             self.sess = tf.Session()  
             self.sess.run(init)
             min_valid_loss = np.nan

--- a/multiphenotype_utils.py
+++ b/multiphenotype_utils.py
@@ -48,8 +48,7 @@ def partition_dataframe_into_binary_and_continuous(df):
     print("Partitioning dataframe into binary and continuous columns")
     phenotypes_to_exclude = [
         'individual_id',
-        'age_sex___age', 
-        'age_sex___self_report_female']
+        'age_sex___age']
     feature_names = []
     binary_features = []
     continuous_features = []
@@ -124,11 +123,11 @@ def get_continuous_features_as_matrix(df, return_cols=False):
     X_continuous = X[:, continuous_feature_idxs]
     continuous_feature_names = [feature_names[idx] for idx in continuous_feature_idxs]
     # Sanity checks
-    phenotypes_to_exclude = [
+    sanity_check_non_continuous_phenotypes = [
         'individual_id',
         'age_sex___age',
         'age_sex___self_report_female']
-    for phenotype in phenotypes_to_exclude: 
+    for phenotype in sanity_check_non_continuous_phenotypes: 
         assert phenotype not in continuous_feature_names
 
     if return_cols:

--- a/multiphenotype_utils.py
+++ b/multiphenotype_utils.py
@@ -48,7 +48,8 @@ def partition_dataframe_into_binary_and_continuous(df):
     print("Partitioning dataframe into binary and continuous columns")
     phenotypes_to_exclude = [
         'individual_id',
-        'age_sex___age']
+        'age_sex___age', 
+        'age_sex___self_report_female']
     feature_names = []
     binary_features = []
     continuous_features = []
@@ -119,21 +120,21 @@ def cluster_and_plot_correlation_matrix(C, column_names, how_to_sort):
     plt.show()
 
 def get_continuous_features_as_matrix(df, return_cols=False):
-    cols_to_keep = list(col for col in df.columns if (df[col].dtype == 'float64'))
-
+    X, binary_feature_idxs, continuous_feature_idxs, feature_names = partition_dataframe_into_binary_and_continuous(df)
+    X_continuous = X[:, continuous_feature_idxs]
+    continuous_feature_names = [feature_names[idx] for idx in continuous_feature_idxs]
     # Sanity checks
     phenotypes_to_exclude = [
         'individual_id',
         'age_sex___age',
         'age_sex___self_report_female']
     for phenotype in phenotypes_to_exclude: 
-        assert phenotype not in cols_to_keep
+        assert phenotype not in continuous_feature_names
 
-    reduced_df = df[cols_to_keep]
     if return_cols:
-        return reduced_df.values, cols_to_keep
+        return X_continuous, continuous_feature_names
     else:
-        return reduced_df.values
+        return X_continuous
 
 def assert_zero_mean(df):
     print(np.mean(get_continuous_features_as_matrix(df), axis=0))

--- a/standard_autoencoder.py
+++ b/standard_autoencoder.py
@@ -4,6 +4,7 @@ from multiphenotype_utils import (get_continuous_features_as_matrix, add_id, rem
 import pandas as pd
 import tensorflow as tf
 from dimreducer import DimReducer
+from copy import deepcopy
 
 from general_autoencoder import GeneralAutoencoder
 
@@ -18,10 +19,10 @@ class StandardAutoencoder(GeneralAutoencoder):
 
         super(StandardAutoencoder, self).__init__(**kwargs)   
         # Does not include input_dim, but includes last hidden layer
-        self.encoder_layer_sizes = encoder_layer_sizes
+        self.encoder_layer_sizes = deepcopy(encoder_layer_sizes) # make a deepcopy so we don't modify the original data accidentally. 
         self.k = self.encoder_layer_sizes[-1]
 
-        self.decoder_layer_sizes = decoder_layer_sizes
+        self.decoder_layer_sizes = deepcopy(decoder_layer_sizes)
         
         self.non_linearity = tf.nn.relu
         self.initialization_function = self.glorot_init


### PR DESCRIPTION
@kohpangwei does this look reasonable to you? 

only use one method, partition_dataframe_into_binary_and_continuous, to do main work of feature extraction. keep get_continuous_features_as_matrix as a wrapper because many methods use it.